### PR TITLE
escape values passed in API to server

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'base', '0';
 requires 'constant', '0';
 requires 'Digest::SHA1', '0';
 requires 'XML::Fast', '0';
+requires 'URI::Escape', '0';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';

--- a/lib/API/BigBlueButton/Requests.pm
+++ b/lib/API/BigBlueButton/Requests.pm
@@ -12,6 +12,7 @@ use warnings;
 
 use Digest::SHA1 qw/ sha1_hex /;
 use Carp qw/ confess /;
+use URI::Escape ;
 
 use constant {
     REQUIRE_CREATE_PARAMS => [ qw/ meetingID / ],
@@ -424,7 +425,7 @@ $params:
 sub generate_url_query {
     my ( $self, $params ) = @_;
 
-    my $string = CORE::join( '&', map { "$_=$params->{$_}" } sort keys %{ $params } );
+    my $string = CORE::join( '&', map { my $val = uri_escape ($params->{$_}); "$_=$val" } sort keys %{ $params } );
 
     return $string;
 }


### PR DESCRIPTION
In case the values of parameter have space in them the URL gets malformed 
and the requests fails due to checksum not reaching the server. The current
commit fixes this problem.